### PR TITLE
Add random context-switch trace sampling and runner integration

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import argparse
 import os
+import random
 import subprocess
-import psutil
 import sys
 
 executable = "/cluster/work/romankb/dynamorio/build/clients/bin64/drcachesim"
@@ -28,6 +28,116 @@ class Color(Enum):
 
 def cprint(string, color: Color):
     print(color.value + string + Color.ENDC.value)
+
+
+def is_trace_file(filename):
+    return filename.endswith(".gz") or filename.endswith(".xz")
+
+
+def collect_trace_files(traces_directory, include_subdirs):
+    workloads = sorted(os.listdir(traces_directory))
+    trace_files = []
+    for workload in workloads:
+        workload_path = path.join(traces_directory, workload)
+        if include_subdirs:
+            if not path.isdir(workload_path):
+                continue
+            filenames = filter(is_trace_file, sorted(os.listdir(workload_path)))
+            trace_files.extend(map(partial(path.join, workload_path), filenames))
+        elif is_trace_file(workload):
+            trace_files.append(workload_path)
+    return trace_files
+
+
+def parse_trace_set(trace_set):
+    if "=" in trace_set:
+        name, directory = trace_set.split("=", 1)
+        name = name.strip()
+        directory = directory.strip()
+    else:
+        directory = trace_set.strip()
+        name = path.basename(path.normpath(directory))
+    if not name:
+        raise ValueError(f"Trace set '{trace_set}' has an empty name")
+    if not directory:
+        raise ValueError(f"Trace set '{trace_set}' has an empty directory")
+    return name, directory
+
+
+def random_ordered_trace_pairs(trace_files, count, rng):
+    if len(trace_files) < 2 or count <= 0:
+        return []
+
+    max_unique_pairs = len(trace_files) * (len(trace_files) - 1)
+    target_count = min(count, max_unique_pairs)
+    pairs = []
+    seen = set()
+    attempts = 0
+    max_attempts = max(target_count * 20, 100)
+
+    while len(pairs) < target_count and attempts < max_attempts:
+        attempts += 1
+        warmup_trace, context_switch_trace = rng.sample(trace_files, 2)
+        pair = (warmup_trace, context_switch_trace)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        pairs.append(pair)
+
+    if len(pairs) < target_count:
+        for warmup_trace in trace_files:
+            for context_switch_trace in trace_files:
+                if warmup_trace == context_switch_trace:
+                    continue
+                pair = (warmup_trace, context_switch_trace)
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                pairs.append(pair)
+                if len(pairs) >= target_count:
+                    return pairs
+
+    return pairs
+
+
+def make_random_context_switch_experiments(args):
+    trace_sets = [parse_trace_set(trace_set) for trace_set in args.trace_set_dirs]
+    rng = random.Random(args.random_seed)
+    per_set_pairs = []
+
+    for trace_set_name, trace_set_dir in trace_sets:
+        trace_files = collect_trace_files(trace_set_dir, args.subdir)
+        if len(trace_files) < 2:
+            cprint(
+                f"Skipping {trace_set_name}: found {len(trace_files)} trace(s), need at least 2",
+                Color.YELLOW,
+            )
+            per_set_pairs.append((trace_set_name, []))
+            continue
+
+        pairs = random_ordered_trace_pairs(
+            trace_files, args.random_context_switch_combinations, rng
+        )
+        rng.shuffle(pairs)
+        per_set_pairs.append((trace_set_name, pairs))
+
+    experiments = []
+    set_index = 0
+    while len(experiments) < args.random_context_switch_combinations:
+        added_pair = False
+        for _ in range(len(per_set_pairs)):
+            trace_set_name, pairs = per_set_pairs[set_index]
+            set_index = (set_index + 1) % len(per_set_pairs)
+            if not pairs:
+                continue
+            warmup_trace, context_switch_trace = pairs.pop()
+            experiments.append((trace_set_name, warmup_trace, context_switch_trace))
+            added_pair = True
+            break
+        if not added_pair:
+            break
+
+    return experiments
 
 
 def run_experiment(
@@ -129,23 +239,11 @@ def get_perfect_predictor_file(base_path, trace_dir):
 
 
 def main(args):
+    import psutil
+
     global warmup_instructions, evaluation_instructions
     warmup_instructions = args.warmup
     evaluation_instructions = args.eval
-    traces_directory = args.traces_directory[0]
-    workloads = os.listdir(traces_directory)
-    trace_files = []
-    for workload in workloads:
-        if args.subdir:
-            workload_dir = path.join(traces_directory, workload)
-            filenames = filter(
-                lambda trace: trace.endswith(".gz") or trace.endswith(".xz"),
-                os.listdir(workload_dir),
-            )
-            trace_files.extend(map(partial(path.join, workload_dir), filenames))
-        else:
-            if workload.endswith(".gz") or workload.endswith(".xz"):
-                trace_files.append(path.join(traces_directory, workload))
 
     output_dir = args.output_dir[0]
     if args.exec:
@@ -159,40 +257,78 @@ def main(args):
     print(f"RUNNING POOL ON {len(proc.cpu_affinity())}")
     pending_experiments = []
 
-    for trace in trace_files:
-        trace_name = trace_stem(trace)
-        if args.subdir:
-            trace_name = path.split(trace)[0].split("/")[-1]
-
-        result_trace_name = trace_name
-        if args.context_switch_trace:
-            result_trace_name = trace_stem(args.context_switch_trace)
-
-        output_subdir = path.join(output_dir, result_trace_name)
-
-        # TEST ONLY
-        # run_experiment(trace, output_subdir)
-        if path.exists(output_subdir):
-            files = os.listdir(output_subdir)
-            if any(f.endswith(".txt") for f in files):
-                cprint(f"{output_subdir} already computed", Color.YELLOW)
-
-                continue
-        print(f"Run {result_trace_name} experiment", flush=True)
-        pending_experiments.append(
-            (
-                pool.apply_async(
-                    run_experiment,
-                    [
-                        trace,
-                        output_subdir,
-                        None,
-                        args.context_switch_trace,
-                    ],
-                ),
-                result_trace_name,
-            )
+    if args.trace_set_dirs:
+        scheduled_experiments = make_random_context_switch_experiments(args)
+        print(
+            f"Scheduled {len(scheduled_experiments)} random context-switch combinations",
+            flush=True,
         )
+        for trace_set_name, warmup_trace, context_switch_trace in scheduled_experiments:
+            result_trace_name = (
+                f"{trace_set_name}/{trace_stem(warmup_trace)}_to_"
+                f"{trace_stem(context_switch_trace)}"
+            )
+            output_subdir = path.join(output_dir, result_trace_name)
+
+            if path.exists(output_subdir):
+                files = os.listdir(output_subdir)
+                if any(f.endswith(".txt") for f in files):
+                    cprint(f"{output_subdir} already computed", Color.YELLOW)
+                    continue
+
+            print(f"Run {result_trace_name} experiment", flush=True)
+            pending_experiments.append(
+                (
+                    pool.apply_async(
+                        run_experiment,
+                        [
+                            warmup_trace,
+                            output_subdir,
+                            None,
+                            context_switch_trace,
+                        ],
+                    ),
+                    result_trace_name,
+                )
+            )
+    else:
+        traces_directory = args.traces_directory[0]
+        trace_files = collect_trace_files(traces_directory, args.subdir)
+
+        for trace in trace_files:
+            trace_name = trace_stem(trace)
+            if args.subdir:
+                trace_name = path.split(trace)[0].split("/")[-1]
+
+            result_trace_name = trace_name
+            if args.context_switch_trace:
+                result_trace_name = trace_stem(args.context_switch_trace)
+
+            output_subdir = path.join(output_dir, result_trace_name)
+
+            # TEST ONLY
+            # run_experiment(trace, output_subdir)
+            if path.exists(output_subdir):
+                files = os.listdir(output_subdir)
+                if any(f.endswith(".txt") for f in files):
+                    cprint(f"{output_subdir} already computed", Color.YELLOW)
+
+                    continue
+            print(f"Run {result_trace_name} experiment", flush=True)
+            pending_experiments.append(
+                (
+                    pool.apply_async(
+                        run_experiment,
+                        [
+                            trace,
+                            output_subdir,
+                            None,
+                            args.context_switch_trace,
+                        ],
+                    ),
+                    result_trace_name,
+                )
+            )
 
     # To prevent subprocesses to be killed
     experiments = [
@@ -227,6 +363,31 @@ if __name__ == "__main__":
         type=str,
         nargs=1,
         help="Directory containing all traces in named subfolders",
+    )
+    parser.add_argument(
+        "--trace-set-dirs",
+        dest="trace_set_dirs",
+        metavar="NAME=TRACE_DIRECTORY",
+        type=str,
+        nargs="+",
+        default=None,
+        help=(
+            "Trace sets to sample for random context-switch experiments. "
+            "Each value can be NAME=DIR or just DIR; when set, --traces_directory "
+            "is ignored."
+        ),
+    )
+    parser.add_argument(
+        "--random-context-switch-combinations",
+        type=int,
+        default=50,
+        help="Maximum number of random warmup/context-switch trace pairs to run.",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=None,
+        help="Optional seed for reproducible random trace-pair selection.",
     )
     parser.add_argument(
         "--trace_format",

--- a/idun_runner.sh
+++ b/idun_runner.sh
@@ -30,6 +30,13 @@ warmup=50000000
 simulation=50000000
 mem_per_cpu="5G"
 max_core_count=8
+trace_root="/cluster/work/romankb/dataset/IPC1_new_translated"
+max_trace_combinations=50
+trace_sets=(
+    "spec=${trace_root}/spec"
+    "server=${trace_root}/server"
+    "client=${trace_root}/client"
+)
 #binary_dir=("size_sensitivity")
 #binaries=("ubs" "ubs_unaligned" "ubs_extended" "ubs_unaligned_extended")
 #binaries=("ubs_overhead_isca_extend_lru" "ubs_overhead_isca_lru")
@@ -40,17 +47,29 @@ do
     for bin in ~/ChampSim/bin/$dir/*
     do
         echo $bin
-        # Select random trace for context switch (client or server), spec used for warmup only
-        traces=("client" "server")
-        random_idx=$((RANDOM % ${#traces[@]}))
-        selected_trace=${traces[$random_idx]}
-
-        # Get first trace file from selected trace directory
-        measure_trace=$(ls /cluster/work/romankb/dataset/IPC1_new_translated/${selected_trace}/*.gz | head -n1)
-
-        # IPC-1 Benchmarks with context-switch simulation
-        # Warmup with spec, switch to random trace for simulation
-       srun --account=share-ie-idi -J num-collection-$(basename ${bin})-ctx --mail-user=romankb@ntnu.no --mail-type=FAIL --mem-per-cpu=${mem_per_cpu} -n1 -c$((max_core_count / 2)) -t$timelimit -o /cluster/work/romankb/latency-spec-to-${selected_trace}-${dir}-$(basename ${bin})-%j.out    -e /cluster/work/romankb/latency-spec-to-${selected_trace}-${dir}-$(basename ${bin})-%j.err    python ~/ChampSim/data_collector.py --warmup ${warmup} --evaluation ${simulation} --experiment_executable ${bin} --traces_directory /cluster/work/romankb/dataset/IPC1_new_translated/spec --context-switch-trace "${measure_trace}" --nosub --output_dir /cluster/work/romankb/results/${dir}_${count}${suffix:+_$suffix}_ispass_bench/ipc1_spec_to_${selected_trace}/sizes_$(basename ${bin})/              &>> /cluster/work/romankb/pyrunner_latency_context_switch_$(basename ${bin}).log &
+        # IPC-1 random context-switch combinations. For each input trace set
+        # (SPEC, server, client), data_collector.py samples random ordered pairs:
+        # one warmup trace and a different context-switch trace. Across all sets,
+        # at most ${max_trace_combinations} combinations are launched by this srun.
+        srun --account=share-ie-idi \
+            -J num-collection-$(basename "${bin}")-ctx \
+            --mail-user=romankb@ntnu.no \
+            --mail-type=FAIL \
+            --mem-per-cpu=${mem_per_cpu} \
+            -n1 \
+            -c$((max_core_count / 2)) \
+            -t${timelimit} \
+            -o /cluster/work/romankb/latency-random-ctx-${dir}-$(basename "${bin}")-%j.out \
+            -e /cluster/work/romankb/latency-random-ctx-${dir}-$(basename "${bin}")-%j.err \
+            python ~/ChampSim/data_collector.py \
+                --warmup ${warmup} \
+                --evaluation ${simulation} \
+                --experiment_executable "${bin}" \
+                --trace-set-dirs "${trace_sets[@]}" \
+                --random-context-switch-combinations ${max_trace_combinations} \
+                --nosub \
+                --output_dir /cluster/work/romankb/results/${dir}_${count}${suffix:+_$suffix}_ispass_bench/ipc1_random_context_switch/sizes_$(basename "${bin}")/ \
+            &>> /cluster/work/romankb/pyrunner_latency_context_switch_$(basename "${bin}").log &
         # srun --account=share-ie-idi -J num-collection-$(basename ${bin}) --mail-user=romankb@ntnu.no --mail-type=FAIL --mem-per-cpu=${mem_per_cpu} -n1 -c${max_core_count} -t$timelimit -o /cluster/work/romankb/latency-server-${dir}-$(basename ${bin})-%j.out  -e /cluster/work/romankb/latency-server-${dir}-$(basename ${bin})-%j.err  python ~/ChampSim/data_collector.py --warmup ${warmup} --evaluation ${simulation} --experiment_executable ${bin} --intel --traces_directory /cluster/work/romankb/dataset/dpc4/high_mpki --nosub --output_dir /cluster/work/romankb/results/${dir}_${count}${suffix:+_$suffix}/dpc4/sizes_$(basename ${bin})/            &>> /cluster/work/romankb/pyrunner_latency_fixed_dpc4_$(basename ${bin}).log &
         # SPECCPU / DPC-3 Benchmarks # Deactivated for now - most have little impact, biggest impact however also here
         # srun --account=share-ie-idi -J num-collection-$(basename ${bin}) --mail-user=romankb@ntnu.no --mail-type=FAIL --mem-per-cpu=20G -n1 -c8 -t$timelimit -o /cluster/work/romankb/latency-server-$(basename ${bin})-%j.out  -e /cluster/work/romankb/latency-server-$(basename ${bin})-%j.err  python ~/ChampSim/data_collector.py --warmup ${warmup} --evaluation ${simulation} --experiment_executable ${bin} --intel --traces_directory /cluster/work/romankb/dataset/dpc3                       --nosub --output_dir /cluster/work/romankb/results/${dir}_${count}_${suffix}/dpc3/sizes_$(basename ${bin})/           &>> /cluster/work/romankb/pyrunner_latency_fixed_dpc3_$(basename ${bin}).log &


### PR DESCRIPTION
### Motivation
- Allow experiments to sample a random subset of trace warmup/context-switch pairs from multiple trace sets (e.g. SPEC, server, client) instead of always using a single hard-coded trace. 
- Ensure the sampled pair uses two different traces (warmup != context-switch) and cap the total scheduled combinations to a practical limit (default 50) for Slurm runs.

### Description
- Added trace-set parsing and trace discovery helpers in `data_collector.py` (`is_trace_file`, `collect_trace_files`, `parse_trace_set`) to accept named trace groups and to collect files from directories. 
- Implemented random ordered pair generation that avoids identical warmup/context traces and duplicate pairs (`random_ordered_trace_pairs`) and a round-robin allocator across trace sets (`make_random_context_switch_experiments`).
- Extended `data_collector.py` CLI with `--trace-set-dirs`, `--random-context-switch-combinations`, and `--random-seed`, and updated `main()` to schedule at most the requested number of random combinations while preserving the previous single-directory behavior.
- Kept running behavior unchanged for non-random mode; moved the `psutil` import into `main()` to avoid import-time failures in some environments.
- Updated `idun_runner.sh` to define the SPEC/server/client trace sets, a `max_trace_combinations` limit, and to submit a single Slurm `srun` that invokes `data_collector.py --trace-set-dirs ... --random-context-switch-combinations 50` for each binary.

### Testing
- Ran `python3 -m py_compile data_collector.py` to validate syntax (succeeded). 
- Ran `bash -n idun_runner.sh` to validate shell syntax (succeeded).
- Performed a temporary-trace sampling smoke test using a temporary directory with small sets of fake `.gz` files and exercised `make_random_context_switch_experiments` to assert the requested number of combinations, verify `warmup != context-switch`, and verify coverage across the configured sets (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a2afa25c883239b40f19d5a2b8ad5)