### PR TITLE
Make context-switch trace selection deterministic

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -6,6 +6,7 @@ from os import path
 from pathlib import Path
 
 import argparse
+import hashlib
 import os
 import random
 import subprocess
@@ -64,12 +65,21 @@ def parse_trace_set(trace_set):
     return name, directory
 
 
-def random_ordered_trace_pairs(trace_files, count, rng):
+def deterministic_ordered_trace_pairs(trace_files, count, selection_key):
+    """Select a stable subset of ordered trace pairs.
+
+    The selected pairs depend only on the trace set identity and the sorted trace
+    file list. This keeps every compiled binary on the same warmup/context-switch
+    pairs when the same input directories are used.
+    """
     if len(trace_files) < 2 or count <= 0:
         return []
 
     max_unique_pairs = len(trace_files) * (len(trace_files) - 1)
     target_count = min(count, max_unique_pairs)
+    seed_material = "\0".join([selection_key, *trace_files]).encode()
+    seed = int.from_bytes(hashlib.sha256(seed_material).digest()[:8], "big")
+    rng = random.Random(seed)
     pairs = []
     seen = set()
     attempts = 0
@@ -100,9 +110,8 @@ def random_ordered_trace_pairs(trace_files, count, rng):
     return pairs
 
 
-def make_random_context_switch_experiments(args):
+def make_context_switch_experiments(args):
     trace_sets = [parse_trace_set(trace_set) for trace_set in args.trace_set_dirs]
-    rng = random.Random(args.random_seed)
     per_set_pairs = []
 
     for trace_set_name, trace_set_dir in trace_sets:
@@ -115,10 +124,11 @@ def make_random_context_switch_experiments(args):
             per_set_pairs.append((trace_set_name, []))
             continue
 
-        pairs = random_ordered_trace_pairs(
-            trace_files, args.random_context_switch_combinations, rng
+        pairs = deterministic_ordered_trace_pairs(
+            trace_files,
+            args.random_context_switch_combinations,
+            f"{trace_set_name}={path.abspath(trace_set_dir)}",
         )
-        rng.shuffle(pairs)
         per_set_pairs.append((trace_set_name, pairs))
 
     experiments = []
@@ -138,6 +148,10 @@ def make_random_context_switch_experiments(args):
             break
 
     return experiments
+
+
+def make_random_context_switch_experiments(args):
+    return make_context_switch_experiments(args)
 
 
 def run_experiment(
@@ -258,9 +272,9 @@ def main(args):
     pending_experiments = []
 
     if args.trace_set_dirs:
-        scheduled_experiments = make_random_context_switch_experiments(args)
+        scheduled_experiments = make_context_switch_experiments(args)
         print(
-            f"Scheduled {len(scheduled_experiments)} random context-switch combinations",
+            f"Scheduled {len(scheduled_experiments)} deterministic context-switch combinations",
             flush=True,
         )
         for trace_set_name, warmup_trace, context_switch_trace in scheduled_experiments:
@@ -372,7 +386,7 @@ if __name__ == "__main__":
         nargs="+",
         default=None,
         help=(
-            "Trace sets to sample for random context-switch experiments. "
+            "Trace sets to sample for deterministic context-switch experiments. "
             "Each value can be NAME=DIR or just DIR; when set, --traces_directory "
             "is ignored."
         ),
@@ -380,14 +394,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--random-context-switch-combinations",
         type=int,
-        default=50,
-        help="Maximum number of random warmup/context-switch trace pairs to run.",
+        default=10,
+        help="Maximum number of deterministic warmup/context-switch trace pairs to run.",
     )
     parser.add_argument(
         "--random-seed",
         type=int,
         default=None,
-        help="Optional seed for reproducible random trace-pair selection.",
+        help="Deprecated compatibility option; trace-pair selection is deterministic from input directories.",
     )
     parser.add_argument(
         "--trace_format",

--- a/idun_runner.sh
+++ b/idun_runner.sh
@@ -31,7 +31,7 @@ simulation=50000000
 mem_per_cpu="5G"
 max_core_count=8
 trace_root="/cluster/work/romankb/dataset/IPC1_new_translated"
-max_trace_combinations=50
+max_trace_combinations=10
 trace_sets=(
     "spec=${trace_root}/spec"
     "server=${trace_root}/server"
@@ -47,10 +47,10 @@ do
     for bin in ~/ChampSim/bin/$dir/*
     do
         echo $bin
-        # IPC-1 random context-switch combinations. For each input trace set
-        # (SPEC, server, client), data_collector.py samples random ordered pairs:
-        # one warmup trace and a different context-switch trace. Across all sets,
-        # at most ${max_trace_combinations} combinations are launched by this srun.
+        # IPC-1 deterministic context-switch combinations. Every binary uses
+        # the same warmup/context-switch trace pairs for a given set of input
+        # trace directories. Across all sets, at most ${max_trace_combinations}
+        # combinations are launched by this srun.
         srun --account=share-ie-idi \
             -J num-collection-$(basename "${bin}")-ctx \
             --mail-user=romankb@ntnu.no \


### PR DESCRIPTION
### Motivation

- Random per-run sampling produced different warmup/context-switch trace pairs for each compiled binary, making cross-binary comparisons noisy and non-reproducible. 
- The intent is to pick a small, stable subset of trace-pairs (10) that is identical for every binary given the same input trace directories. 

### Description

- Replace the ad-hoc per-run random sampling with `deterministic_ordered_trace_pairs()` that seeds a local RNG from a SHA-256 of the trace-set identity plus the sorted trace file list so selection depends only on the input directories and file names. 
- Add a thin compatibility alias `make_random_context_switch_experiments()` that forwards to the new deterministic generator and switch the scheduler to call `make_context_switch_experiments()`. 
- Change the default maximum context-switch combinations from `50` to `10` and update CLI/help text to describe deterministic selection. 
- Update `idun_runner.sh` to use `max_trace_combinations=10` and adjust the comments to document deterministic selection across binaries. 

### Testing

- Compiled the modified script with `python -m py_compile data_collector.py` and the check succeeded. 
- Ran a deterministic-selection smoke test that creates temporary trace directories and asserts stable output across runs using a small Python snippet (selection is identical on repeated calls) and it passed. 
- Verified argument help and text changes by running `python data_collector.py --help` and `bash -n idun_runner.sh`, both of which returned without errors. 
- Ran `git diff --check` locally to ensure no whitespace/patch issues, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9275515483238e392f193b7950c4)