### PR TITLE
Deterministic client/server context-switch trace pairing and CLI updates

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -6,6 +6,7 @@ from os import path
 from pathlib import Path
 
 import argparse
+import hashlib
 import os
 import random
 import subprocess
@@ -64,12 +65,35 @@ def parse_trace_set(trace_set):
     return name, directory
 
 
-def random_ordered_trace_pairs(trace_files, count, rng):
-    if len(trace_files) < 2 or count <= 0:
+def deterministic_trace_pairs(
+    warmup_trace_files, context_switch_trace_files, count, selection_key
+):
+    """Select stable warmup/context-switch trace pairs.
+
+    Warmup traces are selected only from the client trace list, and
+    context-switch traces are selected only from the server trace list. The
+    selected pairs depend only on those sorted trace file lists, so every
+    compiled binary uses the same pair subset for the same input directories.
+    """
+    if not warmup_trace_files or not context_switch_trace_files or count <= 0:
         return []
 
-    max_unique_pairs = len(trace_files) * (len(trace_files) - 1)
-    target_count = min(count, max_unique_pairs)
+    all_pairs_count = len(warmup_trace_files) * len(context_switch_trace_files)
+    same_path_pairs_count = len(
+        set(warmup_trace_files).intersection(context_switch_trace_files)
+    )
+    target_count = min(count, max(0, all_pairs_count - same_path_pairs_count))
+    seed_material = "\0".join(
+        [
+            selection_key,
+            "warmup",
+            *warmup_trace_files,
+            "context-switch",
+            *context_switch_trace_files,
+        ]
+    ).encode()
+    seed = int.from_bytes(hashlib.sha256(seed_material).digest()[:8], "big")
+    rng = random.Random(seed)
     pairs = []
     seen = set()
     attempts = 0
@@ -77,7 +101,10 @@ def random_ordered_trace_pairs(trace_files, count, rng):
 
     while len(pairs) < target_count and attempts < max_attempts:
         attempts += 1
-        warmup_trace, context_switch_trace = rng.sample(trace_files, 2)
+        warmup_trace = rng.choice(warmup_trace_files)
+        context_switch_trace = rng.choice(context_switch_trace_files)
+        if warmup_trace == context_switch_trace:
+            continue
         pair = (warmup_trace, context_switch_trace)
         if pair in seen:
             continue
@@ -85,8 +112,8 @@ def random_ordered_trace_pairs(trace_files, count, rng):
         pairs.append(pair)
 
     if len(pairs) < target_count:
-        for warmup_trace in trace_files:
-            for context_switch_trace in trace_files:
+        for warmup_trace in warmup_trace_files:
+            for context_switch_trace in context_switch_trace_files:
                 if warmup_trace == context_switch_trace:
                     continue
                 pair = (warmup_trace, context_switch_trace)
@@ -100,44 +127,64 @@ def random_ordered_trace_pairs(trace_files, count, rng):
     return pairs
 
 
-def make_random_context_switch_experiments(args):
+def require_trace_set(trace_sets, trace_set_name):
+    matches = [
+        trace_set_dir
+        for name, trace_set_dir in trace_sets
+        if name.lower() == trace_set_name
+    ]
+    if not matches:
+        raise ValueError(f"Missing required '{trace_set_name}' trace set")
+    if len(matches) > 1:
+        raise ValueError(f"Found multiple '{trace_set_name}' trace sets")
+    return matches[0]
+
+
+def make_context_switch_experiments(args):
     trace_sets = [parse_trace_set(trace_set) for trace_set in args.trace_set_dirs]
-    rng = random.Random(args.random_seed)
-    per_set_pairs = []
+    client_trace_dir = require_trace_set(trace_sets, "client")
+    server_trace_dir = require_trace_set(trace_sets, "server")
+    ignored_sets = [
+        name for name, _ in trace_sets if name.lower() not in {"client", "server"}
+    ]
 
-    for trace_set_name, trace_set_dir in trace_sets:
-        trace_files = collect_trace_files(trace_set_dir, args.subdir)
-        if len(trace_files) < 2:
-            cprint(
-                f"Skipping {trace_set_name}: found {len(trace_files)} trace(s), need at least 2",
-                Color.YELLOW,
-            )
-            per_set_pairs.append((trace_set_name, []))
-            continue
-
-        pairs = random_ordered_trace_pairs(
-            trace_files, args.random_context_switch_combinations, rng
+    if ignored_sets:
+        cprint(
+            f"Ignoring non-client/server trace set(s): {', '.join(ignored_sets)}",
+            Color.YELLOW,
         )
-        rng.shuffle(pairs)
-        per_set_pairs.append((trace_set_name, pairs))
 
-    experiments = []
-    set_index = 0
-    while len(experiments) < args.random_context_switch_combinations:
-        added_pair = False
-        for _ in range(len(per_set_pairs)):
-            trace_set_name, pairs = per_set_pairs[set_index]
-            set_index = (set_index + 1) % len(per_set_pairs)
-            if not pairs:
-                continue
-            warmup_trace, context_switch_trace = pairs.pop()
-            experiments.append((trace_set_name, warmup_trace, context_switch_trace))
-            added_pair = True
-            break
-        if not added_pair:
-            break
+    client_trace_files = collect_trace_files(client_trace_dir, args.subdir)
+    server_trace_files = collect_trace_files(server_trace_dir, args.subdir)
 
-    return experiments
+    if not client_trace_files:
+        cprint("Skipping context switches: found no client warmup traces", Color.YELLOW)
+        return []
+    if not server_trace_files:
+        cprint(
+            "Skipping context switches: found no server context-switch traces",
+            Color.YELLOW,
+        )
+        return []
+
+    pairs = deterministic_trace_pairs(
+        client_trace_files,
+        server_trace_files,
+        args.random_context_switch_combinations,
+        (
+            f"client={path.abspath(client_trace_dir)};"
+            f"server={path.abspath(server_trace_dir)}"
+        ),
+    )
+
+    return [
+        ("client_to_server", warmup_trace, context_switch_trace)
+        for warmup_trace, context_switch_trace in pairs
+    ]
+
+
+def make_random_context_switch_experiments(args):
+    return make_context_switch_experiments(args)
 
 
 def run_experiment(
@@ -258,9 +305,9 @@ def main(args):
     pending_experiments = []
 
     if args.trace_set_dirs:
-        scheduled_experiments = make_random_context_switch_experiments(args)
+        scheduled_experiments = make_context_switch_experiments(args)
         print(
-            f"Scheduled {len(scheduled_experiments)} random context-switch combinations",
+            f"Scheduled {len(scheduled_experiments)} deterministic context-switch combinations",
             flush=True,
         )
         for trace_set_name, warmup_trace, context_switch_trace in scheduled_experiments:
@@ -372,7 +419,9 @@ if __name__ == "__main__":
         nargs="+",
         default=None,
         help=(
-            "Trace sets to sample for random context-switch experiments. "
+            "Trace sets to sample for deterministic context-switch experiments. "
+            "Provide client=DIR and server=DIR; client traces are used for "
+            "warmup and server traces are used after the context switch. "
             "Each value can be NAME=DIR or just DIR; when set, --traces_directory "
             "is ignored."
         ),
@@ -380,14 +429,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--random-context-switch-combinations",
         type=int,
-        default=50,
-        help="Maximum number of random warmup/context-switch trace pairs to run.",
+        default=10,
+        help=(
+            "Maximum number of deterministic client-warmup/server-context-switch "
+            "trace pairs to run."
+        ),
     )
     parser.add_argument(
         "--random-seed",
         type=int,
         default=None,
-        help="Optional seed for reproducible random trace-pair selection.",
+        help="Deprecated compatibility option; trace-pair selection is deterministic from input directories.",
     )
     parser.add_argument(
         "--trace_format",

--- a/idun_runner.sh
+++ b/idun_runner.sh
@@ -31,11 +31,10 @@ simulation=50000000
 mem_per_cpu="5G"
 max_core_count=8
 trace_root="/cluster/work/romankb/dataset/IPC1_new_translated"
-max_trace_combinations=50
+max_trace_combinations=10
 trace_sets=(
-    "spec=${trace_root}/spec"
-    "server=${trace_root}/server"
     "client=${trace_root}/client"
+    "server=${trace_root}/server"
 )
 #binary_dir=("size_sensitivity")
 #binaries=("ubs" "ubs_unaligned" "ubs_extended" "ubs_unaligned_extended")
@@ -47,10 +46,10 @@ do
     for bin in ~/ChampSim/bin/$dir/*
     do
         echo $bin
-        # IPC-1 random context-switch combinations. For each input trace set
-        # (SPEC, server, client), data_collector.py samples random ordered pairs:
-        # one warmup trace and a different context-switch trace. Across all sets,
-        # at most ${max_trace_combinations} combinations are launched by this srun.
+        # IPC-1 deterministic context-switch combinations. Every binary uses
+        # the same pairs for a given set of input trace directories: warmup
+        # traces come from client and context-switch traces come from server.
+        # At most ${max_trace_combinations} combinations are launched by this srun.
         srun --account=share-ie-idi \
             -J num-collection-$(basename "${bin}")-ctx \
             --mail-user=romankb@ntnu.no \


### PR DESCRIPTION
### Motivation
- Ensure repeatable selection of warmup/context-switch trace pairs across runs by removing per-run randomness and fixing selection to the input directories. 
- Enforce explicit `client`/`server` roles for trace sets to avoid ambiguous cross-set sampling and improve experiment reproducibility.

### Description
- Replace the previous random sampling with `deterministic_trace_pairs` which deterministically selects pairs using a SHA-256-derived seed based on the sorted input trace lists and a selection key. 
- Introduce `make_context_switch_experiments` and `require_trace_set` to require exactly one `client` and one `server` trace set and to ignore other named sets with a warning. 
- Preserve compatibility by keeping `make_random_context_switch_experiments` as a thin wrapper that forwards to `make_context_switch_experiments`, and update `main` to call the new function. 
- Update CLI help text and defaults: change the `--random-context-switch-combinations` default from `50` to `10`, deprecate the `--random-seed` help text, and clarify `--trace-set-dirs` usage to require `client=DIR` and `server=DIR`; add `hashlib` import. 
- Update `idun_runner.sh` to use the new default `max_trace_combinations=10`, reorder and declare `trace_sets` as `client` and `server`, and update comments to reflect deterministic pairing.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9275515483238e392f193b7950c4)